### PR TITLE
Bridge interface cleanup and sdram validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .*.d
 *.o
 .*.sw[po]
+.*.cmd
+*.mod.c
+*.ko

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.bin
+*.blif
+*.asc
+.*.d
+*.o
+.*.sw[po]

--- a/bridge_lib/Makefile
+++ b/bridge_lib/Makefile
@@ -1,17 +1,32 @@
 ARCH = arm
-CROSS_CC = arm-linux-gnueabihf-
-CC = $(CROSS_CC)gcc
-PWD = $(shell pwd)
-CFLAGS = -Wall -g
+CROSS ?= arm-linux-gnueabihf-
+CC = $(CROSS)gcc
+PWD := $(shell pwd)
 
-SRCS = i2c_br.c bw_bridge.c
-OBJS = $(SRCS: .c=.o)
-MAIN = i2c_br
+CFLAGS = \
+        -std=c99 \
+	-g \
+	-O3 \
+        -W \
+        -Wall \
+        -Wextra \
+	-Wp,-MMD,$(dir $@).$(notdir $@).d \
+        -Wp,-MT,$@ \
 
-all: $(MAIN)
+bins-y += sdram
+bins-y += i2c
+bins-y += main
 
-$(MAIN): $(OBJS)
-	$(CC) $(CFLAGS) -o $(MAIN) $(OBJS)
+all: $(bins-y)
+
+$(bins-y):
+	$(CC) -o $@ $^
+
+sdram: sdram.o bw_bridge.o
+i2c: i2c_br.o bw_bridge.o
+main: main.o bw_bridge.o
 
 clean:
-	$(RM) *.o *~ $(MAIN)
+	$(RM) *.o *~ $(bins-y)
+
+-include .*.d

--- a/bridge_lib/bw_bridge.h
+++ b/bridge_lib/bw_bridge.h
@@ -9,6 +9,9 @@
 #include <time.h>
 #include <errno.h>
 
+#define BW_BRIDGE_MEM_ADR 0x01000000
+#define BW_BRIDGE_MEM_SIZE 0x20000
+
 struct bridge {
 	void		*virt_addr;
 	int		mem_dev;

--- a/bridge_lib/i2c_br.c
+++ b/bridge_lib/i2c_br.c
@@ -1,13 +1,9 @@
 #include <stdio.h>
 #include "bw_bridge.h"
 
-#define BW_BRIDGE_MEM_ADR 0x01000000
-#define BW_BRIDGE_MEM_SIZE 0x20000
-
 int main()
 {
 	struct bridge br;
-	int i;
 	void *ptr;
 	char text[] = {0x0, 0x0};
 	char rd_text[11];
@@ -24,7 +20,7 @@ int main()
 	*(uint16_t *)(ptr) |= (1<<5);
 	*(uint16_t *)(ptr) |= 2;
 
-	for (i=0;i<sizeof(text);i++) {
+	for (size_t i=0;i<sizeof(text);i++) {
 
 		*(uint16_t *)(ptr + 2) = text[i];
 
@@ -61,7 +57,7 @@ int main()
 	rd_text[i] = (*(uint16_t *)(ptr) >> 8);
 	}
 
-	for (i=0;i<sizeof(rd_text);i++)
+	for (size_t i=0;i<sizeof(rd_text);i++)
 		printf("%c", rd_text[i]);
 
 

--- a/bridge_lib/main.c
+++ b/bridge_lib/main.c
@@ -1,9 +1,6 @@
 #include <stdio.h>
 #include "bw_bridge.h"
 
-#define BW_BRIDGE_MEM_ADR 0x01000000
-#define BW_BRIDGE_MEM_SIZE 0x20000
-
 int main()
 {
 	struct bridge br;

--- a/bridge_lib/sdram.c
+++ b/bridge_lib/sdram.c
@@ -13,34 +13,47 @@
 
 typedef struct __attribute__((__packed__))
 {
-	volatile uint16_t reset:1; // offset 0
-	volatile uint16_t busy:1;
-	volatile uint16_t rd_enable:1;
-	volatile uint16_t wr_enable:1;
-	volatile uint16_t rd_busy:1;
+	volatile uint8_t reset:1; // offset 0
+	volatile uint8_t busy:1;
+	volatile uint8_t rd_enable:1;
+	volatile uint8_t wr_enable:1;
+	volatile uint8_t rd_busy:1;
+	uint8_t unused;
 
-	volatile uint32_t addr; // 25 bits, offset 1
-	volatile uint16_t wr_data; // 8 bits, offset 3
-	volatile uint16_t rd_data; // 8 bits, offset 4
+	volatile uint16_t addr_lo; // 16 bits, offset 1
+	volatile uint16_t addr_hi; //  9 bits, offset 1
+	volatile uint16_t wr_data; //  8 bits, offset 3
+	volatile uint16_t rd_data; //  8 bits, offset 4
 } bw_sdram_t;
 
-int main()
+int main(int argc, char **argv)
 {
+	uint16_t xor = argc > 1 ? strtol(argv[1], NULL, 0) : 0;
+
 	struct bridge br;
 	if (bridge_init(&br, BW_BRIDGE_MEM_ADR, BW_BRIDGE_MEM_SIZE) < 0)
+	{
+		perror("mmap");
 		return 1;
+	}
 
 	bw_sdram_t * const sdram = br.virt_addr;
+	printf("sdram=%p\n", sdram);
+	printf("addr=%p %p\n", &sdram->addr_lo, &sdram->addr_hi);
+	printf("rd_data=%p\n", &sdram->rd_data);
+
 
 	// clr reset
 	sdram->reset = 1;
 
-	for (int i=0;i<100;i++) {
+	printf("writing....\n");
+	for (size_t i=0;i<100;i++) {
 		//set sdram address
-		sdram->addr = 0x120051 + i;
+		sdram->addr_hi = 0x12;
+		sdram->addr_lo = 0x51 + i;
 
 		//set sdram data
-		sdram->wr_data = i;
+		sdram->wr_data = i ^ xor;
 
 		//set wr enable flag
 		sdram->wr_enable = 1;
@@ -53,9 +66,11 @@ int main()
 		sdram->wr_enable = 0;
 	}
 
-	for (int i=0;i<100;i++) {
+	printf("reading....\n");
+	for (size_t i=0;i<100;i++) {
 		//set sdra, address
-		sdram->addr = 0x120051 + i;
+		sdram->addr_hi = 0x12;
+		sdram->addr_lo = 0x51 + i;
 
 		//set rd enable flag
 		sdram->rd_enable = 1;
@@ -71,7 +86,13 @@ int main()
 		// clr rd enable bit
 		sdram->rd_enable = 0;
 
-		printf("data[%x]=%x\n", i, sdram->rd_data);
+		const uint16_t data = sdram->rd_data;
+
+		printf("data[%x]=%x%s\n",
+			i,
+			data,
+			data == (i ^ xor) ? "" : " BAD"
+		);
  	}
 
 	bridge_close(&br);

--- a/bridge_lib/sdram.c
+++ b/bridge_lib/sdram.c
@@ -1,4 +1,3 @@
-
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -12,58 +11,69 @@
 
 #include "bw_bridge.h"
 
+typedef struct __attribute__((__packed__))
+{
+	volatile uint16_t reset:1; // offset 0
+	volatile uint16_t busy:1;
+	volatile uint16_t rd_enable:1;
+	volatile uint16_t wr_enable:1;
+	volatile uint16_t rd_busy:1;
+
+	volatile uint32_t addr; // 25 bits, offset 1
+	volatile uint16_t wr_data; // 8 bits, offset 3
+	volatile uint16_t rd_data; // 8 bits, offset 4
+} bw_sdram_t;
+
 int main()
 {
 	struct bridge br;
-	int i, j;
-	void *ptr;
-
-
 	if (bridge_init(&br, BW_BRIDGE_MEM_ADR, BW_BRIDGE_MEM_SIZE) < 0)
 		return 1;
 
-	ptr = br.virt_addr;
+	bw_sdram_t * const sdram = br.virt_addr;
 
 	// clr reset
-	*(uint16_t *)(ptr) |= 1;
+	sdram->reset = 1;
 
-	for (i=0;i<100;i++) {
+	for (int i=0;i<100;i++) {
 		//set sdram address
-		*(uint16_t *)(ptr + 2) = 0x51+i;
-		*(uint16_t *)(ptr + 4) = 0x12;
+		sdram->addr = 0x120051 + i;
 
 		//set sdram data
-		*(uint16_t *)(ptr + 6) = i;
+		sdram->wr_data = i;
 
 		//set wr enable flag
-		*(uint16_t *)(ptr) |= 8;
+		sdram->wr_enable = 1;
 
 		//waiting for clr busy bit
-		while ((*(uint16_t *)(ptr) & 2));
+		while (sdram->busy)
+			;
 
 		// clr we enable bit
-		*(uint16_t *)(ptr) &= ~8;
+		sdram->wr_enable = 0;
 	}
 
-	for (i=0;i<100;i++) {
+	for (int i=0;i<100;i++) {
 		//set sdra, address
-                *(uint16_t *)(ptr + 2) = 0x51+i;
-                *(uint16_t *)(ptr + 4) = 0x12;
+		sdram->addr = 0x120051 + i;
 
 		//set rd enable flag
-		*(uint16_t *)(ptr) |= 4;
+		sdram->rd_enable = 1;
 
 		// waiting for clr busy bit
-                while ((*(uint16_t *)(ptr) & 2));
+                while (sdram->busy)
+			;
 
 		// waiting for clr rd ready bit
-	       	while ((*(uint16_t *)(ptr) & 16));
+		while (sdram->rd_busy)
+			;
 
 		// clr rd enable bit
-		*(uint16_t *)(ptr) &= ~4;
+		sdram->rd_enable = 0;
 
-		printf("data: %x  %x\n", *(uint16_t *)(ptr + 8), i);
+		printf("data[%x]=%x\n", i, sdram->rd_data);
  	}
+
 	bridge_close(&br);
 
 	return 0;

--- a/bridge_lib/sdram.c
+++ b/bridge_lib/sdram.c
@@ -10,50 +10,7 @@
 #include <time.h>
 #include <errno.h>
 
-#define BW_BRIDGE_MEM_ADR 0x01000000
-#define BW_BRIDGE_MEM_SIZE 0x20000
-
-struct bridge {
-	void		*virt_addr;
-	int		mem_dev;
-	uint32_t	alloc_mem_size;
-	void		*mem_pointer;
-};
-
-int bridge_init(struct bridge *br, uint32_t mem_address, uint32_t mem_size) {
-	uint32_t page_mask;
-	uint32_t page_size;
-
-	page_size = sysconf(_SC_PAGESIZE);
-	br->alloc_mem_size = (((mem_size / page_size) + 1) * page_size);
-	page_mask = (page_size - 1);
-
-	br->mem_dev = open("/dev/mem", O_RDWR | O_SYNC);
-	if (br->mem_dev < 0)
-		return -EPERM;
-
-	br->mem_pointer = mmap(NULL,
-		               br->alloc_mem_size,
-			       PROT_READ | PROT_WRITE,
-                               MAP_SHARED,
-                               br->mem_dev,
-                               (mem_address & ~page_mask));
-
-	if(br->mem_pointer == MAP_FAILED) {
-	      return -ENOMEM;
-	}
-
-	br->virt_addr = (br->mem_pointer + (mem_address & page_mask));
-
-	return 0;
-}
-
-void bridge_close(struct bridge *br) {
-	if (munmap(br->mem_pointer, br->alloc_mem_size) == -1)
-		perror("Error un-mmapping the file");
-
-	close(br->mem_dev);
-}
+#include "bw_bridge.h"
 
 int main()
 {


### PR DESCRIPTION
This change builds all of the different bridge tests (main, i2c, sdram) and replaces the explicit offsets with a memory mapped sdram control structure.  It also validates the values read from the sdram.