### PR TITLE
map in the other pmod pins

### DIFF
--- a/examples/test/pinmap.pcf
+++ b/examples/test/pinmap.pcf
@@ -15,3 +15,10 @@ set_io led[2] 31
 set_io led[3] 32
 
 set_io pmod1[0] 38
+set_io pmod1[1] 37
+set_io pmod1[2] 41
+set_io pmod1[3] 39
+set_io pmod1[4] 43
+set_io pmod1[5] 42
+set_io pmod1[6] 45
+set_io pmod1[7] 44


### PR DESCRIPTION
I spent a while trying to figure out why my LEDs on the PMOD port were not being driven. It would be great if there were some sort of warning or error for top module inputs that are not connected to the outside world.